### PR TITLE
588 move sorting and filtering on library page to backend

### DIFF
--- a/packages/apiserver/src/resources/materials/material.resolver.ts
+++ b/packages/apiserver/src/resources/materials/material.resolver.ts
@@ -16,6 +16,7 @@ import {
   RolesTypes,
   SearchInput,
   SearchOneMaterial,
+  SortDir,
   UpdateMaterialInput,
 } from '@mimir/global-types';
 import { Notification } from '../notifications/notification.entity';
@@ -37,11 +38,21 @@ export class MaterialResolver {
 
   @Query(() => [Material])
   async getAllMaterials(
-    @Args('locations') locations: Array<number>,
+    @Args('input') searchInput: SearchInput,
+    @Args('sortBy') sortBy: string,
+    @Args('sortDir') sortDir: SortDir,
     @Args('limit') limit: number,
-    @Args('offset') offset: number
+    @Args('offset') offset: number,
+    @CurrentUser() user: Person
   ) {
-    return this.materialService.allMaterials(locations, limit, offset);
+    return this.materialService.search(
+      searchInput,
+      sortBy,
+      sortDir,
+      limit,
+      offset,
+      user.type === RolesTypes.MANAGER
+    );
   }
 
   @Query(() => Material)
@@ -69,17 +80,6 @@ export class MaterialResolver {
     } catch (e) {
       throw new GraphQLError(e.message);
     }
-  }
-
-  @Query(() => [Material])
-  async searchOfMaterials(
-    @Args('input') searchInput: SearchInput,
-    @CurrentUser() user: Person
-  ) {
-    return this.materialService.search(
-      searchInput,
-      user.type === RolesTypes.MANAGER
-    );
   }
 
   @Query(() => [Material])

--- a/packages/apiserver/src/resources/materials/material.schema.graphql
+++ b/packages/apiserver/src/resources/materials/material.schema.graphql
@@ -74,8 +74,19 @@ input DonateBookInput {
 }
 
 input SearchInput {
-  search: String
   locations: [Int!]
+  excludeLocations: [Int!]
+  search: String
+  overdue: Boolean
+  accepted: Boolean
+  categories: [String!]
+  excludeCategories: [String!]
+  authors: [String!]
+  excludeAuthors: [String!]
+  statuses: [String!]
+  excludeStatuses: [String!]
+  types: [String!]
+  excludeTypes: [String!]
 }
 
 type ResponseMetadata {
@@ -121,10 +132,20 @@ type IMetaOfMaterial {
   material: IMaterialMeta
 }
 
+enum SortDir {
+  ASC
+  DESC
+}
+
 extend type Query {
-  getAllMaterials(locations: [Int!], limit: Int, offset: Int): [Material]!
+  getAllMaterials(
+    input: SearchInput
+    limit: Int
+    offset: Int
+    sortBy: String
+    sortDir: SortDir
+  ): [Material]!
   getMaterialById(id: ID!): Material!
-  searchOfMaterials(input: SearchInput!): [Material]
   getMaterialByIdentifier(input: SearchOneMaterial!): Material!
   getMaterialByIdentifierFromMetadata(identifier: String!): IMetaOfMaterial
   getAllDonatedMaterialsByPerson(id: ID!): [Material]

--- a/packages/apiserver/src/resources/materials/material.service.ts
+++ b/packages/apiserver/src/resources/materials/material.service.ts
@@ -4,6 +4,7 @@ import {
   DonateBookInput,
   RolesTypes,
   SearchInput,
+  SortDir,
   StatusTypes,
 } from '@mimir/global-types';
 import { Status } from '../statuses/status.entity';
@@ -13,6 +14,7 @@ import { GraphQLError } from 'graphql';
 import axios from 'axios';
 import { normalizeIdentifier } from '@mimir/helper-functions';
 import { ConfigService } from '@nestjs/config';
+import { SelectQueryBuilder } from 'typeorm/query-builder/SelectQueryBuilder';
 
 @Injectable()
 export class MaterialService {
@@ -24,38 +26,20 @@ export class MaterialService {
 
   async search(
     searchInput: SearchInput,
+    sortBy: string,
+    sortDir: SortDir,
+    limit: number,
+    offset: number,
     selectHidden = false
   ): Promise<Material[]> {
-    const { search, locations } = searchInput;
-    if (!search) {
-      return [];
+    const query = this.buildSearchQuery(searchInput, selectHidden);
+
+    query.addOrderBy(sortBy ? `material.${sortBy}` : 'title', sortDir || 'ASC');
+    if (limit != undefined) {
+      query.limit(limit);
     }
-
-    const query = Material.createQueryBuilder('material')
-      .where('material.location_id IN (:...locations)', { locations })
-      .andWhere(
-        `${
-          search
-            ? '(material.title ILIKE :text OR material.author ILIKE :text)'
-            : ''
-        }`,
-        { text: `%${search}%` }
-      )
-      .addOrderBy('title', 'ASC');
-
-    if (!selectHidden) {
-      query.innerJoin(
-        'status',
-        'currentStatus',
-        'material.current_status_id = currentStatus.id'
-      );
-      query.andWhere('currentStatus.status NOT IN (:...statuses)', {
-        statuses: [
-          StatusTypes.PENDING,
-          StatusTypes.REJECTED,
-          StatusTypes.SUSPEND,
-        ],
-      });
+    if (offset != undefined) {
+      query.offset(offset);
     }
 
     return query.getMany();
@@ -104,22 +88,6 @@ export class MaterialService {
     }
   }
 
-  async allMaterials(
-    locations: Array<number>,
-    limit?: number,
-    offset?: number
-  ) {
-    const paginationPage = (offset - 1) * limit;
-    const elements = await Material.createQueryBuilder('material')
-      .leftJoinAndSelect('material.status', 'status')
-      .where('material.location_id IN (:...locations)', { locations })
-      .orderBy('material.created_at', 'ASC')
-      .limit(limit || null)
-      .offset(paginationPage || null)
-      .getMany();
-    return elements;
-  }
-
   async getMaterialByIdentifierFromMetadata(identifier: string) {
     try {
       const responseMetadataService = await axios.get(
@@ -157,5 +125,363 @@ export class MaterialService {
       await manager.remove(Material, material);
       return material;
     });
+  }
+
+  private buildSearchQuery(
+    searchInput: SearchInput,
+    selectHidden: boolean
+  ): SelectQueryBuilder<Material> {
+    const queryBuilder = Material.createQueryBuilder('material').innerJoin(
+      'status',
+      'currentStatus',
+      'material.current_status_id = currentStatus.id'
+    );
+    let isFirstWhere = true;
+    if (
+      this.addHiddenStatusesCondition(queryBuilder, selectHidden, isFirstWhere)
+    ) {
+      isFirstWhere = false;
+    }
+    if (!searchInput) {
+      return queryBuilder;
+    }
+
+    if (
+      this.addLocationsCondition(
+        queryBuilder,
+        searchInput.locations,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addExcludeLocationsCondition(
+        queryBuilder,
+        searchInput.excludeLocations,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addSearchCondition(queryBuilder, searchInput.search, isFirstWhere)
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addStatusesCondition(
+        queryBuilder,
+        searchInput.statuses,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addExcludeStatusesCondition(
+        queryBuilder,
+        searchInput.excludeStatuses,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addOverdueCondition(queryBuilder, searchInput.overdue, isFirstWhere)
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addAcceptedCondition(
+        queryBuilder,
+        searchInput.accepted,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addAuthorsCondition(queryBuilder, searchInput.authors, isFirstWhere)
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addExcludeAuthorsCondition(
+        queryBuilder,
+        searchInput.excludeAuthors,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (this.addTypesCondition(queryBuilder, searchInput.types, isFirstWhere)) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addExcludeTypesCondition(
+        queryBuilder,
+        searchInput.excludeTypes,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addCategoriesCondition(
+        queryBuilder,
+        searchInput.categories,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    if (
+      this.addExcludeCategoriesCondition(
+        queryBuilder,
+        searchInput.excludeCategories,
+        isFirstWhere
+      )
+    ) {
+      isFirstWhere = false;
+    }
+    return queryBuilder;
+  }
+
+  private addLocationsCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    locations: number[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (locations?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        'material.location_id IN (:...locations)',
+        { locations }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addExcludeLocationsCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    excludeLocations: number[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (excludeLocations?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        'material.location_id NOT IN (:...excludeLocations)',
+        {
+          excludeLocations,
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addSearchCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    search: string,
+    isFirstWhere: boolean
+  ): boolean {
+    if (search) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `${
+          search
+            ? '(material.title ILIKE :text OR material.author ILIKE :text)'
+            : ''
+        }`,
+        { text: `%${search}%` }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addStatusesCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    statuses: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (statuses?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        'currentStatus.status IN (:...statuses)',
+        {
+          statuses,
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addExcludeStatusesCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    excludeStatuses: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (excludeStatuses?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        'currentStatus.status NOT IN (:...excludeStatuses)',
+        {
+          excludeStatuses,
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addOverdueCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    overdue: boolean,
+    isFirstWhere: boolean
+  ): boolean {
+    if (overdue === true || overdue === false) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        overdue
+          ? `currentStatus.returnDate < NOW()`
+          : `(currentStatus.returnDate IS NULL OR currentStatus.returnDate > NOW())`
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addAcceptedCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    accepted: boolean,
+    isFirstWhere: boolean
+  ): boolean {
+    if (accepted === true || accepted === false) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `currentStatus.status ${
+          accepted ? 'NOT' : ''
+        } IN (:...notAcceptedStatuses)`,
+        { notAcceptedStatuses: [StatusTypes.PENDING, StatusTypes.REJECTED] }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addAuthorsCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    authors: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (authors?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `material.author IN (:...authors)`,
+        {
+          authors,
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addExcludeAuthorsCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    excludeAuthors: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (excludeAuthors?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `material.author NOT IN (:...excludeAuthors)`,
+        {
+          excludeAuthors,
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addTypesCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    types: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (types?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `material.type IN (:...types)`,
+        {
+          types,
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addExcludeTypesCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    excludeTypes: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (excludeTypes?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `material.type NOT IN (:...excludeTypes)`,
+        {
+          excludeTypes,
+        }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addCategoriesCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    categories: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (categories?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `material.category IN (:...categories)`,
+        { categories }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addExcludeCategoriesCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    excludeCategories: string[],
+    isFirstWhere: boolean
+  ): boolean {
+    if (excludeCategories?.length) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        `material.category NOT IN (:...excludeCategories)`,
+        { excludeCategories }
+      );
+      return true;
+    }
+    return false;
+  }
+
+  private addHiddenStatusesCondition(
+    queryBuilder: SelectQueryBuilder<Material>,
+    selectHidden: boolean,
+    isFirstWhere: boolean
+  ): boolean {
+    if (!selectHidden) {
+      queryBuilder[isFirstWhere ? 'where' : 'andWhere'](
+        'currentStatus.status NOT IN (:...hiddenStatuses)',
+        {
+          hiddenStatuses: [
+            StatusTypes.PENDING,
+            StatusTypes.REJECTED,
+            StatusTypes.SUSPEND,
+          ],
+        }
+      );
+      return true;
+    }
+    return false;
   }
 }

--- a/packages/apollo-client/src/graphql.schema.json
+++ b/packages/apollo-client/src/graphql.schema.json
@@ -3143,6 +3143,18 @@
             "description": null,
             "args": [
               {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SearchInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "limit",
                 "description": null,
                 "type": {
@@ -3155,31 +3167,35 @@
                 "deprecationReason": null
               },
               {
-                "name": "locations",
+                "name": "offset",
                 "description": null,
                 "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
               },
               {
-                "name": "offset",
+                "name": "sortBy",
                 "description": null,
                 "type": {
                   "kind": "SCALAR",
-                  "name": "Int",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortDir",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "SortDir",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -3788,39 +3804,6 @@
             "deprecationReason": null
           },
           {
-            "name": "searchOfMaterials",
-            "description": null,
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "SearchInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Material",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "welcome",
             "description": null,
             "args": [],
@@ -4021,6 +4004,158 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "accepted",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "authors",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "categories",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excludeAuthors",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excludeCategories",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excludeLocations",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excludeStatuses",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excludeTypes",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "locations",
             "description": null,
             "type": {
@@ -4041,12 +4176,64 @@
             "deprecationReason": null
           },
           {
+            "name": "overdue",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "search",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statuses",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "types",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -4102,6 +4289,29 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SortDir",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/apollo-client/src/lib/generated/client-types.ts
+++ b/packages/apollo-client/src/lib/generated/client-types.ts
@@ -402,7 +402,6 @@ export type Query = {
   getReasonOfBlock?: Maybe<BlockedUsers>;
   getStatusesByMaterial: Array<Maybe<Status>>;
   getStatusesByPerson: Array<Maybe<Status>>;
-  searchOfMaterials?: Maybe<Array<Maybe<Material>>>;
   welcome: Scalars['String'];
 };
 
@@ -413,9 +412,11 @@ export type QueryGetAllDonatedMaterialsByPersonArgs = {
 
 
 export type QueryGetAllMaterialsArgs = {
+  input?: InputMaybe<SearchInput>;
   limit?: InputMaybe<Scalars['Int']>;
-  locations?: InputMaybe<Array<Scalars['Int']>>;
   offset?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<Scalars['String']>;
+  sortDir?: InputMaybe<SortDir>;
 };
 
 
@@ -499,11 +500,6 @@ export type QueryGetStatusesByPersonArgs = {
   person_id: Scalars['ID'];
 };
 
-
-export type QuerySearchOfMaterialsArgs = {
-  input: SearchInput;
-};
-
 export type RemoveLocationInput = {
   location_id: Scalars['Int'];
 };
@@ -526,14 +522,30 @@ export type ResponseMetadata = {
 };
 
 export type SearchInput = {
+  accepted?: InputMaybe<Scalars['Boolean']>;
+  authors?: InputMaybe<Array<Scalars['String']>>;
+  categories?: InputMaybe<Array<Scalars['String']>>;
+  excludeAuthors?: InputMaybe<Array<Scalars['String']>>;
+  excludeCategories?: InputMaybe<Array<Scalars['String']>>;
+  excludeLocations?: InputMaybe<Array<Scalars['Int']>>;
+  excludeStatuses?: InputMaybe<Array<Scalars['String']>>;
+  excludeTypes?: InputMaybe<Array<Scalars['String']>>;
   locations?: InputMaybe<Array<Scalars['Int']>>;
+  overdue?: InputMaybe<Scalars['Boolean']>;
   search?: InputMaybe<Scalars['String']>;
+  statuses?: InputMaybe<Array<Scalars['String']>>;
+  types?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type SearchOneMaterial = {
   identifier: Scalars['String'];
   locations?: InputMaybe<Array<Scalars['Int']>>;
 };
+
+export enum SortDir {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
 
 export type Status = {
   __typename?: 'Status';
@@ -746,27 +758,33 @@ export type GetAllLocationsQueryVariables = Exact<{ [key: string]: never; }>;
 export type GetAllLocationsQuery = { __typename?: 'Query', getAllLocations: Array<{ __typename?: 'Location', id: string, location: string } | null> };
 
 export type GetAllMaterialsQueryVariables = Exact<{
-  locations?: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
+  input?: InputMaybe<SearchInput>;
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<Scalars['String']>;
+  sortDir?: InputMaybe<SortDir>;
 }>;
 
 
 export type GetAllMaterialsQuery = { __typename?: 'Query', getAllMaterials: Array<{ __typename?: 'Material', author: string, category: string, created_at: any, id: string, id_type: string, identifier: string, description: string, is_donated: boolean, picture?: string | null, title: string, type: string, updated_at: any, claimCount: number, notifications: Array<{ __typename?: 'Notification', material_id?: number | null, person_id: number } | null>, currentStatus?: { __typename?: 'Status', status: string, person_id: number, returnDate?: any | null } | null } | null> };
 
 export type GetAllMaterialsForDonateQueryVariables = Exact<{
-  locations?: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
+  input?: InputMaybe<SearchInput>;
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<Scalars['String']>;
+  sortDir?: InputMaybe<SortDir>;
 }>;
 
 
 export type GetAllMaterialsForDonateQuery = { __typename?: 'Query', getAllMaterials: Array<{ __typename?: 'Material', id: string, title: string, claimCount: number, currentStatus?: { __typename?: 'Status', id: string, status: string, returnDate?: any | null, person: { __typename?: 'Person', id: string, username: string, avatar: string } } | null } | null> };
 
 export type GetAllMaterialsForManagerQueryVariables = Exact<{
-  locations?: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
+  input?: InputMaybe<SearchInput>;
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<Scalars['String']>;
+  sortDir?: InputMaybe<SortDir>;
 }>;
 
 
@@ -859,12 +877,15 @@ export type GetStatusesByMaterialQueryVariables = Exact<{
 export type GetStatusesByMaterialQuery = { __typename?: 'Query', getStatusesByMaterial: Array<{ __typename?: 'Status', id: string, status: string, created_at: any, returnDate?: any | null, person: { __typename?: 'Person', id: string, avatar: string, username: string, statuses?: Array<{ __typename?: 'Status', material_id: number, status: string, created_at: any, returnDate?: any | null } | null> | null } } | null> };
 
 export type SearchOfMaterialsQueryVariables = Exact<{
-  search?: InputMaybe<Scalars['String']>;
-  locations?: InputMaybe<Array<Scalars['Int']> | Scalars['Int']>;
+  input?: InputMaybe<SearchInput>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<Scalars['String']>;
+  sortDir?: InputMaybe<SortDir>;
 }>;
 
 
-export type SearchOfMaterialsQuery = { __typename?: 'Query', searchOfMaterials?: Array<{ __typename?: 'Material', title: string, created_at: any, picture?: string | null, author: string, category: string, id: string, claimCount: number, currentStatus?: { __typename?: 'Status', id: string, created_at: any, status: string, returnDate?: any | null, person: { __typename?: 'Person', id: string, username: string } } | null } | null> | null };
+export type SearchOfMaterialsQuery = { __typename?: 'Query', getAllMaterials: Array<{ __typename?: 'Material', title: string, created_at: any, picture?: string | null, author: string, category: string, id: string, claimCount: number, currentStatus?: { __typename?: 'Status', id: string, created_at: any, status: string, returnDate?: any | null, person: { __typename?: 'Person', id: string, username: string } } | null } | null> };
 
 
 export const AcceptBookDocument = gql`
@@ -1646,8 +1667,14 @@ export type GetAllLocationsQueryHookResult = ReturnType<typeof useGetAllLocation
 export type GetAllLocationsLazyQueryHookResult = ReturnType<typeof useGetAllLocationsLazyQuery>;
 export type GetAllLocationsQueryResult = Apollo.QueryResult<GetAllLocationsQuery, GetAllLocationsQueryVariables>;
 export const GetAllMaterialsDocument = gql`
-    query GetAllMaterials($locations: [Int!], $limit: Int, $offset: Int) {
-  getAllMaterials(locations: $locations, limit: $limit, offset: $offset) {
+    query GetAllMaterials($input: SearchInput, $limit: Int, $offset: Int, $sortBy: String, $sortDir: SortDir) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     author
     category
     created_at
@@ -1686,9 +1713,11 @@ export const GetAllMaterialsDocument = gql`
  * @example
  * const { data, loading, error } = useGetAllMaterialsQuery({
  *   variables: {
- *      locations: // value for 'locations'
+ *      input: // value for 'input'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
+ *      sortBy: // value for 'sortBy'
+ *      sortDir: // value for 'sortDir'
  *   },
  * });
  */
@@ -1704,8 +1733,14 @@ export type GetAllMaterialsQueryHookResult = ReturnType<typeof useGetAllMaterial
 export type GetAllMaterialsLazyQueryHookResult = ReturnType<typeof useGetAllMaterialsLazyQuery>;
 export type GetAllMaterialsQueryResult = Apollo.QueryResult<GetAllMaterialsQuery, GetAllMaterialsQueryVariables>;
 export const GetAllMaterialsForDonateDocument = gql`
-    query GetAllMaterialsForDonate($locations: [Int!], $limit: Int, $offset: Int) {
-  getAllMaterials(locations: $locations, limit: $limit, offset: $offset) {
+    query GetAllMaterialsForDonate($input: SearchInput, $limit: Int, $offset: Int, $sortBy: String, $sortDir: SortDir) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     id
     title
     currentStatus {
@@ -1735,9 +1770,11 @@ export const GetAllMaterialsForDonateDocument = gql`
  * @example
  * const { data, loading, error } = useGetAllMaterialsForDonateQuery({
  *   variables: {
- *      locations: // value for 'locations'
+ *      input: // value for 'input'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
+ *      sortBy: // value for 'sortBy'
+ *      sortDir: // value for 'sortDir'
  *   },
  * });
  */
@@ -1753,8 +1790,14 @@ export type GetAllMaterialsForDonateQueryHookResult = ReturnType<typeof useGetAl
 export type GetAllMaterialsForDonateLazyQueryHookResult = ReturnType<typeof useGetAllMaterialsForDonateLazyQuery>;
 export type GetAllMaterialsForDonateQueryResult = Apollo.QueryResult<GetAllMaterialsForDonateQuery, GetAllMaterialsForDonateQueryVariables>;
 export const GetAllMaterialsForManagerDocument = gql`
-    query GetAllMaterialsForManager($locations: [Int!], $limit: Int, $offset: Int) {
-  getAllMaterials(locations: $locations, limit: $limit, offset: $offset) {
+    query GetAllMaterialsForManager($input: SearchInput, $limit: Int, $offset: Int, $sortBy: String, $sortDir: SortDir) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     id
     title
     category
@@ -1786,9 +1829,11 @@ export const GetAllMaterialsForManagerDocument = gql`
  * @example
  * const { data, loading, error } = useGetAllMaterialsForManagerQuery({
  *   variables: {
- *      locations: // value for 'locations'
+ *      input: // value for 'input'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
+ *      sortBy: // value for 'sortBy'
+ *      sortDir: // value for 'sortDir'
  *   },
  * });
  */
@@ -2366,8 +2411,14 @@ export type GetStatusesByMaterialQueryHookResult = ReturnType<typeof useGetStatu
 export type GetStatusesByMaterialLazyQueryHookResult = ReturnType<typeof useGetStatusesByMaterialLazyQuery>;
 export type GetStatusesByMaterialQueryResult = Apollo.QueryResult<GetStatusesByMaterialQuery, GetStatusesByMaterialQueryVariables>;
 export const SearchOfMaterialsDocument = gql`
-    query SearchOfMaterials($search: String, $locations: [Int!]) {
-  searchOfMaterials(input: {search: $search, locations: $locations}) {
+    query SearchOfMaterials($input: SearchInput, $limit: Int, $offset: Int, $sortBy: String, $sortDir: SortDir) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     title
     created_at
     picture
@@ -2401,8 +2452,11 @@ export const SearchOfMaterialsDocument = gql`
  * @example
  * const { data, loading, error } = useSearchOfMaterialsQuery({
  *   variables: {
- *      search: // value for 'search'
- *      locations: // value for 'locations'
+ *      input: // value for 'input'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *      sortBy: // value for 'sortBy'
+ *      sortDir: // value for 'sortDir'
  *   },
  * });
  */

--- a/packages/apollo-client/src/lib/queries/getAllMaterials.gql
+++ b/packages/apollo-client/src/lib/queries/getAllMaterials.gql
@@ -1,5 +1,17 @@
-query GetAllMaterials($locations: [Int!], $limit: Int, $offset: Int) {
-  getAllMaterials(locations: $locations, limit: $limit, offset: $offset) {
+query GetAllMaterials(
+  $input: SearchInput
+  $limit: Int
+  $offset: Int
+  $sortBy: String
+  $sortDir: SortDir
+) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     author
     category
     created_at

--- a/packages/apollo-client/src/lib/queries/getAllMaterialsForDonate.gql
+++ b/packages/apollo-client/src/lib/queries/getAllMaterialsForDonate.gql
@@ -1,5 +1,17 @@
-query GetAllMaterialsForDonate($locations: [Int!], $limit: Int, $offset: Int) {
-  getAllMaterials(locations: $locations, limit: $limit, offset: $offset) {
+query GetAllMaterialsForDonate(
+  $input: SearchInput
+  $limit: Int
+  $offset: Int
+  $sortBy: String
+  $sortDir: SortDir
+) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     id
     title
     currentStatus {

--- a/packages/apollo-client/src/lib/queries/getAllMaterialsForManager.gql
+++ b/packages/apollo-client/src/lib/queries/getAllMaterialsForManager.gql
@@ -1,5 +1,17 @@
-query GetAllMaterialsForManager($locations: [Int!], $limit: Int, $offset: Int) {
-  getAllMaterials(locations: $locations, limit: $limit, offset: $offset) {
+query GetAllMaterialsForManager(
+  $input: SearchInput
+  $limit: Int
+  $offset: Int
+  $sortBy: String
+  $sortDir: SortDir
+) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     id
     title
     category

--- a/packages/apollo-client/src/lib/queries/searchOfMaterials.gql
+++ b/packages/apollo-client/src/lib/queries/searchOfMaterials.gql
@@ -1,5 +1,17 @@
-query SearchOfMaterials($search: String, $locations: [Int!]) {
-  searchOfMaterials(input: { search: $search, locations: $locations }) {
+query SearchOfMaterials(
+  $input: SearchInput
+  $limit: Int
+  $offset: Int
+  $sortBy: String
+  $sortDir: SortDir
+) {
+  getAllMaterials(
+    input: $input
+    limit: $limit
+    offset: $offset
+    sortBy: $sortBy
+    sortDir: $sortDir
+  ) {
     title
     created_at
     picture

--- a/packages/frontapp/src/app/components/BooksByCategory/bookList.tsx
+++ b/packages/frontapp/src/app/components/BooksByCategory/bookList.tsx
@@ -24,85 +24,19 @@ export type IMaterial = Pick<
 > & { currentStatus: IStatus | null };
 
 interface IBookList {
-  allData: IMaterial[];
-  searchParams: URLSearchParams;
+  materials: IMaterial[];
+  filters: string[];
 }
-const BookList: FC<IBookList> = ({ allData, searchParams }) => {
-  const authors = searchParams.getAll('authors');
-  const availability = searchParams.getAll('availability');
-  const categories = searchParams.getAll('categories');
-  const items = searchParams.getAll('items');
-  const sortBy = searchParams.getAll('sortby');
-  const [filteredData, setFilteredData] = useState<IMaterial[]>([]);
-  const [allFilters, setAllFilters] = useState<string[]>([
-    ...authors,
-    ...availability,
-    ...categories,
-    ...items,
-    ...sortBy,
-  ]);
-
-  useEffect(() => {
-    setAllFilters([
-      ...authors,
-      ...availability,
-      ...categories,
-      ...items,
-      ...sortBy,
-    ]);
-
-    if (searchParams.toString() === '') {
-      setFilteredData(allData);
-      return;
-    }
-    let allBooks = allData;
-    if (authors.length !== 0) {
-      const filter = allBooks.filter(
-        (book: IMaterial) => book && authors.includes(book.author)
-      );
-      !authors.includes('All') && (allBooks = filter);
-    }
-    if (categories.length !== 0) {
-      const filter = allBooks.filter(
-        (book: IMaterial) => book && categories.includes(book.category)
-      );
-
-      !categories.includes('All') && (allBooks = filter);
-    }
-    if (items.length !== 0) {
-      const filter = allBooks.filter(
-        (book: IMaterial) => book && items.includes(book.type)
-      );
-      allBooks = filter;
-    }
-    if (availability.length !== 0) {
-      const filter = allBooks.filter((book: IMaterial) =>
-        availability.includes(book.currentStatus?.status as string)
-      );
-      !availability.includes('All') && (allBooks = filter);
-    }
-    if (sortBy.length !== 0) {
-      if (sortBy[0].localeCompare('By date added')) {
-        const filter = allBooks.slice().sort((firstBook, secondBook) => {
-          const firstDate = new Date(firstBook.created_at);
-          const secondDate = new Date(secondBook.created_at);
-          return firstDate.getTime() - secondDate.getTime();
-        });
-        allBooks = filter;
-      }
-    }
-    setFilteredData(allBooks);
-  }, [searchParams]);
-
+const BookList: FC<IBookList> = ({ materials, filters }) => {
   return (
     <div data-testid="bookList">
       <Header>
-        {t('Readers.TitleFiltered')} - {filteredData.length}
+        {t('Readers.TitleFiltered')} - {materials.length}
       </Header>
-      <Tags chosenTags={allFilters} />
+      <Tags chosenTags={filters} />
       <WrapperList>
-        {filteredData.length !== 0 ? (
-          filteredData.map((material: IMaterial) => (
+        {materials.length !== 0 ? (
+          materials.map((material: IMaterial) => (
             <BookCard
               key={material.id}
               id={material.id}

--- a/packages/frontapp/src/app/components/BooksByCategory/index.spec.tsx
+++ b/packages/frontapp/src/app/components/BooksByCategory/index.spec.tsx
@@ -33,11 +33,10 @@ const mockMaterial = [
 ];
 
 const params = ['searchParams'];
-const searchParams = new URLSearchParams(params[0]);
 
 describe('BooksByCategory', () => {
   it(' bookList should render correctly', () => {
-    render(<BookList allData={mockMaterial} searchParams={searchParams} />);
+    render(<BookList materials={mockMaterial} filters={params} />);
     expect(screen.getByTestId('bookList')).toBeInTheDocument();
   });
 

--- a/packages/frontapp/src/app/components/BooksByCategory/index.tsx
+++ b/packages/frontapp/src/app/components/BooksByCategory/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useGetAllMaterialsQuery } from '@mimir/apollo-client';
+import { SortDir, useGetAllMaterialsQuery } from '@mimir/apollo-client';
 import { useSearchParams } from 'react-router-dom';
 import { useAppSelector } from '../../hooks/useTypedSelector';
 import { locationIds } from '../../store/slices/userSlice';
@@ -14,8 +14,37 @@ import { colors } from '@mimir/ui-kit';
 const BooksByCategory = () => {
   const locations = useAppSelector(locationIds);
   const [searchParams] = useSearchParams();
+
+  const authors = searchParams.getAll('authors');
+  const availability = searchParams.getAll('availability');
+  const categories = searchParams.getAll('categories');
+  const items = searchParams.getAll('items');
+  const sortBy = searchParams.getAll('sortby');
+  const filters = [
+    ...authors,
+    ...availability,
+    ...categories,
+    ...items,
+    ...sortBy,
+  ];
+
   const { data, loading, error } = useGetAllMaterialsQuery({
-    variables: { locations },
+    variables: {
+      input: {
+        locations,
+        categories,
+        authors,
+        types: items,
+        statuses: availability,
+      },
+      sortBy:
+        sortBy?.[0]?.localeCompare('By date added') === 0
+          ? 'created_at'
+          : sortBy?.[0],
+      ...(sortBy?.[0]?.localeCompare('By date added') === 0 && {
+        sortDir: SortDir.Asc,
+      }),
+    },
   });
 
   useEffect(() => {
@@ -24,23 +53,28 @@ const BooksByCategory = () => {
     }
   }, [error]);
 
-  if (loading)
+  if (loading) {
     return (
       <WrapperLoader>
         <Loader height={100} width={100} color={`${colors.accent_color}`} />
       </WrapperLoader>
     );
+  }
 
-  if (!data) return <ErrorType500 />;
-  if (data.getAllMaterials.length === 0) return <ItemsNotFound />;
+  if (!data) {
+    return <ErrorType500 />;
+  }
+  if (data.getAllMaterials.length === 0) {
+    return <ItemsNotFound />;
+  }
 
   return (
     data && (
       <>
         <BackButton />
         <BookList
-          allData={data.getAllMaterials as IMaterial[]}
-          searchParams={searchParams}
+          materials={data.getAllMaterials as IMaterial[]}
+          filters={filters}
         />
       </>
     )

--- a/packages/frontapp/src/app/components/CategorySearch/index.tsx
+++ b/packages/frontapp/src/app/components/CategorySearch/index.tsx
@@ -25,7 +25,7 @@ const CategorySearch: FC<IProps> = ({ setActive }) => {
     GetAllMaterialsQuery['getAllMaterials']
   >([]);
   const { data, error } = useGetAllMaterialsQuery({
-    variables: { locations },
+    variables: { input: { locations } },
     fetchPolicy: 'no-cache',
   });
 

--- a/packages/frontapp/src/app/components/ListAllItems/index.tsx
+++ b/packages/frontapp/src/app/components/ListAllItems/index.tsx
@@ -40,7 +40,7 @@ const ListAllItems = () => {
   const { searchMaterials } = useAppSelector((state) => state.materials);
 
   const { data, loading, error } = useGetAllMaterialsForManagerQuery({
-    variables: { locations },
+    variables: { input: { locations } },
     fetchPolicy: 'no-cache',
   });
 

--- a/packages/frontapp/src/app/components/MaterialSearch/index.tsx
+++ b/packages/frontapp/src/app/components/MaterialSearch/index.tsx
@@ -25,7 +25,7 @@ const MaterialSearch: FC<IProps> = ({ setActive }) => {
     GetAllMaterialsQuery['getAllMaterials']
   >([]);
   const { data, error } = useGetAllMaterialsQuery({
-    variables: { locations },
+    variables: { input: { locations } },
     fetchPolicy: 'no-cache',
   });
 

--- a/packages/frontapp/src/app/components/SearchByBookOrAuthor/index.tsx
+++ b/packages/frontapp/src/app/components/SearchByBookOrAuthor/index.tsx
@@ -28,7 +28,7 @@ const SearchByBookOrAuthor: FC<{ path: string }> = ({ path }) => {
   const navigate = useNavigate();
 
   const { data, error } = useSearchOfMaterialsQuery({
-    variables: { search: debounceSearch, locations },
+    variables: { input: { search: debounceSearch, locations } },
     skip: !debounceSearch,
   });
 
@@ -38,12 +38,12 @@ const SearchByBookOrAuthor: FC<{ path: string }> = ({ path }) => {
 
   useEffect(() => {
     if (data) {
-      dispatch(setSearchMaterials(data?.searchOfMaterials));
+      dispatch(setSearchMaterials(data?.getAllMaterials));
     }
   }, [data]);
 
   useEffect(() => {
-    setIsShowListSuggestions(!!(search && data?.searchOfMaterials?.length));
+    setIsShowListSuggestions(!!(search && data?.getAllMaterials?.length));
   }, [debounceSearch, data]);
 
   const removeSuggestionSearchWindow = useCallback(() => {
@@ -80,7 +80,7 @@ const SearchByBookOrAuthor: FC<{ path: string }> = ({ path }) => {
       />
       {isShowListSuggestions && (
         <SearchSuggestions
-          materials={data?.searchOfMaterials}
+          materials={data?.getAllMaterials}
           removeSuggestionSearchWindow={removeSuggestionSearchWindow}
         />
       )}

--- a/packages/frontapp/src/app/components/SearchSuggestions/index.spec.tsx
+++ b/packages/frontapp/src/app/components/SearchSuggestions/index.spec.tsx
@@ -5,7 +5,7 @@ import SearchSuggestions from './index';
 import { SearchOfMaterialsQuery } from '@mimir/apollo-client';
 import '@testing-library/jest-dom';
 
-const mockListOfMaterials: SearchOfMaterialsQuery['searchOfMaterials'] = [
+const mockListOfMaterials: SearchOfMaterialsQuery['getAllMaterials'] = [
   {
     __typename: 'Material',
     id: '1',
@@ -55,7 +55,7 @@ describe('SearchSuggestionsComponent', () => {
   it('render when data is null', () => {
     render(
       <SearchSuggestions
-        materials={null}
+        materials={[]}
         removeSuggestionSearchWindow={() => {}}
       />
     );

--- a/packages/frontapp/src/app/components/SearchSuggestions/index.tsx
+++ b/packages/frontapp/src/app/components/SearchSuggestions/index.tsx
@@ -28,7 +28,7 @@ const WrapperList = styled.div`
 `;
 
 export interface IPropsSearchSuggestions {
-  materials: SearchOfMaterialsQuery['searchOfMaterials'];
+  materials?: SearchOfMaterialsQuery['getAllMaterials'];
   removeSuggestionSearchWindow: () => void;
 }
 

--- a/packages/frontapp/src/app/components/StatisticsModal/index.spec.tsx
+++ b/packages/frontapp/src/app/components/StatisticsModal/index.spec.tsx
@@ -9,7 +9,7 @@ import { nextTick } from '../../../helpers/tests/nextTick';
 const materialsMock = {
   request: {
     query: GetAllMaterialsForManagerDocument,
-    variables: { locations: [] },
+    variables: { input: { locations: [] } },
   },
   result: {
     data: {

--- a/packages/frontapp/src/app/components/StatisticsModal/index.tsx
+++ b/packages/frontapp/src/app/components/StatisticsModal/index.tsx
@@ -130,7 +130,7 @@ const LegendColor = styled.div`
 const StatisticsModal: FC<StatisticsModal> = ({ isActive, setIsActive }) => {
   const locations = useAppSelector(locationIds);
   const { data, error } = useGetAllMaterialsForManagerQuery({
-    variables: { locations },
+    variables: { input: { locations } },
     fetchPolicy: 'no-cache',
   });
   const bookItems = data?.getAllMaterials!.map((material) => {

--- a/packages/frontapp/src/app/pages/BookPreview.tsx
+++ b/packages/frontapp/src/app/pages/BookPreview.tsx
@@ -114,7 +114,7 @@ const BookPreview = ({ donate }: BookPreviewProps) => {
     });
   const { data: getAllMaterials, error: getAllMaterialsError } =
     useGetAllMaterialsQuery({
-      variables: { locations },
+      variables: { input: { locations } },
     });
   const filteredHistory = useMemo(
     () =>

--- a/packages/frontapp/src/app/pages/DonatesFromUser.tsx
+++ b/packages/frontapp/src/app/pages/DonatesFromUser.tsx
@@ -9,7 +9,7 @@ import DonatesFromUserContent from '../components/DonatesFromUserContent/Donates
 const DonatesFromUser = () => {
   const locations = useAppSelector(locationIds);
   const { data, error } = useGetAllMaterialsQuery({
-    variables: { locations },
+    variables: { input: { locations } },
     fetchPolicy: 'no-cache',
   });
   const [search, setSearch] = useState<string>('');

--- a/packages/frontapp/src/app/pages/HomePage.tsx
+++ b/packages/frontapp/src/app/pages/HomePage.tsx
@@ -104,7 +104,7 @@ const HomePage: FC = () => {
     loading: materialsLoading,
     error: errorMaterials,
   } = useGetAllMaterialsForDonateQuery({
-    variables: { locations },
+    variables: { input: { locations } },
     fetchPolicy: 'no-cache',
   });
 

--- a/packages/global-types/src/lib/global-types.ts
+++ b/packages/global-types/src/lib/global-types.ts
@@ -7,6 +7,11 @@
 
 /* tslint:disable */
 /* eslint-disable */
+export enum SortDir {
+    ASC = "ASC",
+    DESC = "DESC"
+}
+
 export enum Permissions {
     GRANT_REVOKE_MANAGER = "GRANT_REVOKE_MANAGER"
 }
@@ -88,8 +93,19 @@ export interface DonateBookInput {
 }
 
 export interface SearchInput {
-    search?: Nullable<string>;
     locations?: Nullable<number[]>;
+    excludeLocations?: Nullable<number[]>;
+    search?: Nullable<string>;
+    overdue?: Nullable<boolean>;
+    accepted?: Nullable<boolean>;
+    categories?: Nullable<string[]>;
+    excludeCategories?: Nullable<string[]>;
+    authors?: Nullable<string[]>;
+    excludeAuthors?: Nullable<string[]>;
+    statuses?: Nullable<string[]>;
+    excludeStatuses?: Nullable<string[]>;
+    types?: Nullable<string[]>;
+    excludeTypes?: Nullable<string[]>;
 }
 
 export interface CreateMessageInput {
@@ -156,9 +172,8 @@ export interface IQuery {
     getAllTakenItems(person_id: number): Nullable<Status>[] | Promise<Nullable<Status>[]>;
     getItemsForClaimHistory(person_id: number): Nullable<Status>[] | Promise<Nullable<Status>[]>;
     getAllLocations(): Nullable<Location>[] | Promise<Nullable<Location>[]>;
-    getAllMaterials(locations?: Nullable<number[]>, limit?: Nullable<number>, offset?: Nullable<number>): Nullable<Material>[] | Promise<Nullable<Material>[]>;
+    getAllMaterials(input?: Nullable<SearchInput>, limit?: Nullable<number>, offset?: Nullable<number>, sortBy?: Nullable<string>, sortDir?: Nullable<SortDir>): Nullable<Material>[] | Promise<Nullable<Material>[]>;
     getMaterialById(id: string): Material | Promise<Material>;
-    searchOfMaterials(input: SearchInput): Nullable<Nullable<Material>[]> | Promise<Nullable<Nullable<Material>[]>>;
     getMaterialByIdentifier(input: SearchOneMaterial): Material | Promise<Material>;
     getMaterialByIdentifierFromMetadata(identifier: string): Nullable<IMetaOfMaterial> | Promise<Nullable<IMetaOfMaterial>>;
     getAllDonatedMaterialsByPerson(id: string): Nullable<Nullable<Material>[]> | Promise<Nullable<Nullable<Material>[]>>;


### PR DESCRIPTION
- Removed SearchOfMaterials query.
- Instead, expanded GetAllMaterials with input allowing to filter and sort materials by multiple parameters.
- Moved filtering and sorting logic to backend.

Closes #588 