### PR TITLE
Loading svg images from S3 is blocked by CORS

### DIFF
--- a/packages/api-util/src/lib/DigitalOcean/digital-ocean.service.ts
+++ b/packages/api-util/src/lib/DigitalOcean/digital-ocean.service.ts
@@ -1,10 +1,12 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import * as AWS from 'aws-sdk';
 import { v4 as uuidv4 } from 'uuid';
+import { ContentType } from 'aws-sdk/clients/s3';
 
 type IProps = {
   originalname: string;
   buffer: Buffer;
+  mimetype: ContentType;
 };
 
 @Injectable()
@@ -31,6 +33,7 @@ export class DigitalOceanService {
             Key: fileName,
             Body: file.buffer,
             ACL: 'public-read',
+            ContentType: file.mimetype,
           },
           (error: AWS.AWSError) => {
             if (!error) {

--- a/packages/apiserver/src/data-transfer/data-transfer.service.ts
+++ b/packages/apiserver/src/data-transfer/data-transfer.service.ts
@@ -39,6 +39,7 @@ export class DataTransferService {
     const url = await this.digitalOceanService.createFile({
       originalname: material.picture,
       buffer: picture.data,
+      mimetype: picture.headers['content-type'],
     });
     await Material.update(material.id, {
       originalPicture: material.picture,

--- a/packages/metadata-service/src/readers/abebooks.service/index.ts
+++ b/packages/metadata-service/src/readers/abebooks.service/index.ts
@@ -45,6 +45,7 @@ export class AbeBooksService {
     const img = await this.digitalOceanService.createFile({
       originalname: url.imageUrl,
       buffer: pic.data,
+      mimetype: pic.headers['content-type'],
     });
     const material: Prisma.MaterialCreateInput = {
       title: title,

--- a/packages/metadata-service/src/readers/abebooks.service/index.ts
+++ b/packages/metadata-service/src/readers/abebooks.service/index.ts
@@ -45,7 +45,7 @@ export class AbeBooksService {
     const img = await this.digitalOceanService.createFile({
       originalname: url.imageUrl,
       buffer: pic.data,
-      mimetype: pic.headers['content-type'],
+      mimetype: pic?.headers?.['content-type'],
     });
     const material: Prisma.MaterialCreateInput = {
       title: title,

--- a/packages/metadata-service/src/readers/chitai-gorod.service/index.ts
+++ b/packages/metadata-service/src/readers/chitai-gorod.service/index.ts
@@ -41,6 +41,7 @@ export class ChitaiGorodService {
     const img = await this.digitalOceanService.createFile({
       originalname: `https://img-gorod.ru${result.image_url}`,
       buffer: pic.data,
+      mimetype: pic.headers['content-type'],
     });
     if (!result) return null;
     const material: Prisma.MaterialCreateInput = {

--- a/packages/metadata-service/src/readers/chitai-gorod.service/index.ts
+++ b/packages/metadata-service/src/readers/chitai-gorod.service/index.ts
@@ -41,7 +41,7 @@ export class ChitaiGorodService {
     const img = await this.digitalOceanService.createFile({
       originalname: `https://img-gorod.ru${result.image_url}`,
       buffer: pic.data,
-      mimetype: pic.headers['content-type'],
+      mimetype: pic?.headers?.['content-type'],
     });
     if (!result) return null;
     const material: Prisma.MaterialCreateInput = {

--- a/packages/metadata-service/src/readers/labirint.service/index.ts
+++ b/packages/metadata-service/src/readers/labirint.service/index.ts
@@ -39,6 +39,7 @@ export class LabirintService {
     const img = await this.digitalOceanService.createFile({
       originalname: $('.book-img-cover').attr('src'),
       buffer: pic.data,
+      mimetype: pic.headers['content-type'],
     });
     const title = $('#product-title').find('h1').text().split(': ')[1];
     const author = $('.authors').first().text().split(': ')[1].split(',');

--- a/packages/metadata-service/src/readers/labirint.service/index.ts
+++ b/packages/metadata-service/src/readers/labirint.service/index.ts
@@ -39,7 +39,7 @@ export class LabirintService {
     const img = await this.digitalOceanService.createFile({
       originalname: $('.book-img-cover').attr('src'),
       buffer: pic.data,
-      mimetype: pic.headers['content-type'],
+      mimetype: pic?.headers?.['content-type'],
     });
     const title = $('#product-title').find('h1').text().split(': ')[1];
     const author = $('.authors').first().text().split(': ')[1].split(',');

--- a/packages/metadata-service/src/readers/ozby.service/index.ts
+++ b/packages/metadata-service/src/readers/ozby.service/index.ts
@@ -120,6 +120,7 @@ export class OzbyService {
     const img = await this.digitalOceanService.createFile({
       originalname: $('.b-product-photo__picture-self img').first().attr('src'),
       buffer: pic.data,
+      mimetype: pic.headers['content-type'],
     });
     const year = Number(items.year);
     delete items.year;

--- a/packages/metadata-service/src/readers/ozby.service/index.ts
+++ b/packages/metadata-service/src/readers/ozby.service/index.ts
@@ -120,7 +120,7 @@ export class OzbyService {
     const img = await this.digitalOceanService.createFile({
       originalname: $('.b-product-photo__picture-self img').first().attr('src'),
       buffer: pic.data,
-      mimetype: pic.headers['content-type'],
+      mimetype: pic?.headers?.['content-type'],
     });
     const year = Number(items.year);
     delete items.year;


### PR DESCRIPTION
svg images were blocked by CORS because application/octet-stream mimetype was set for all images during upload.
Setting correct mimetype fixes the issue with displaying svg images.

Closes #651 